### PR TITLE
Integrate pre-commit tool

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,58 @@
+repos:
+-   repo: https://github.com/asottile/add-trailing-comma
+    rev: v2.4.0
+    hooks:
+    -   id: add-trailing-comma
+
+-   repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
+    hooks:
+    -   id: isort
+        args:
+        - --honor-noqa
+
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: no-commit-to-branch
+        args: [--branch, main]
+    -   id: check-merge-conflict
+    -   id: double-quote-string-fixer
+    -   id: requirements-txt-fixer
+    -   id: check-yaml
+    -   id: check-docstring-first
+    -   id: end-of-file-fixer
+    -   id: name-tests-test
+    -   id: check-ast
+    -   id: debug-statements
+
+-   repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.5.1
+    hooks:
+    -   id: forbid-crlf
+    -   id: remove-crlf
+    -   id: forbid-tabs
+    -   id: remove-tabs
+        args: [--whitespaces-count, '4']
+
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.2.0
+    hooks:
+    -   id: mypy
+
+-   repo: local
+    hooks:
+    -   id: pylint
+        name: pylint
+        entry: pylint
+        language: system
+        types: [python]
+        require_serial: true
+
+-   repo: https://github.com/PyCQA/flake8
+    rev: 6.0.0
+    hooks:
+    -   id: flake8
+        additional_dependencies:
+        -   flake8-docstrings


### PR DESCRIPTION
Add the following pre-commit [hooks](http://pre-commit.com/hooks.html) into the configuration file: 
-  no-commit-to-branch
-  [add-trailing-comma](https://github.com/asottile/add-trailing-comma)
-  [remove-tabs](https://github.com/Lucas-C/pre-commit-hooks)
-  trailing-whitespace
-  check-merge-conflict
-  double-quote-string-fixer
-  requirements-txt-fixer
-  check-yaml
-  check-docstring-first
-  end-of-file-fixer
-  name-tests-test
-  check-ast
-  debug-statements
-  flake8
-  [pydocstyle](http://www.pydocstyle.org/en/5.0.1/usage.html#usage-with-the-pre-commit-git-hooks-framework)
-  pylint using "local" mode
-  [mypy](https://github.com/pre-commit/mirrors-mypy.git)

[See more about pre-commit tool using.](https://pre-commit.com/)

Resolves #12 


