### PR TITLE
Add integration of GitHub Action CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: 🧪
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  linters:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Fetch the src
+      uses: actions/checkout@v3
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.11
+
+    - name: Install pre-commit
+      run: python -m pip install --upgrade pre-commit
+
+    - name: Run pre-commit
+      run: python -m pre_commit run --all-files
+      env:
+        SKIP: no-commit-to-branch

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![🧪 CI/CD](https://github.com/kpi-web-guild/django-girls-blog-Martolivna/actions/workflows/ci.yml/badge.svg)](https://github.com/kpi-web-guild/django-girls-blog-Martolivna/actions/workflows/ci.yml?query=branch%3Amain)


### PR DESCRIPTION
It enables to automatically run pre-commit tool on push and PR events, exсept the `no-commit-to-branch` check to avoid a false-positive faillure when merging PR. This patch also adds the GitHub Actions CI/CD badge into README to display the workflow status.

Resolves #14 